### PR TITLE
Prevent crash when current app has no bundle identifier

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -62,6 +62,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @objc func appSpecificMenuClick(_ sender: Any) {
+        defer {
+            updateUI()
+        }
+
         guard let bundleIdentifier = currentApplicationBundleIdentifier else {
             grayscaleLog("unknown")
 
@@ -85,8 +89,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         UserDefaults.standard.setValue(perAppGrayscaleEnabledDict, forKey: perAppGrayscaleEnabledDictName)
-
-        updateUI()
     }
 
     func toggleDefaultGrayscale() {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -19,6 +19,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     // application state management
 
     var currentApplication: NSRunningApplication!
+    var currentApplicationBundleIdentifier: String? { currentApplication.bundleIdentifier }
     var defaultGrayscaleEnabled: Bool = false
     var perAppGrayscaleEnabledDict: [String: Bool] = [:]
 
@@ -61,20 +62,26 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @objc func appSpecificMenuClick(_ sender: Any) {
+        guard let bundleIdentifier = currentApplicationBundleIdentifier else {
+            grayscaleLog("unknown")
+
+            return
+        }
+
         let senderObject = sender as! NSObject
         if senderObject == appSpecificSubMenuItemGrayscaleDefault {
             grayscaleLog("default")
-            perAppGrayscaleEnabledDict.removeValue(forKey: currentApplication.bundleIdentifier!)
+            perAppGrayscaleEnabledDict.removeValue(forKey: bundleIdentifier)
         }
 
         if senderObject == appSpecificSubMenuItemGrayscaleEnabled {
             grayscaleLog("enabled")
-            perAppGrayscaleEnabledDict[currentApplication.bundleIdentifier!] = true
+            perAppGrayscaleEnabledDict[bundleIdentifier] = true
         }
 
         if senderObject == appSpecificSubMenuItemGrayscaleDisabled {
             grayscaleLog("disabled")
-            perAppGrayscaleEnabledDict[currentApplication.bundleIdentifier!] = false
+            perAppGrayscaleEnabledDict[bundleIdentifier] = false
         }
 
         UserDefaults.standard.setValue(perAppGrayscaleEnabledDict, forKey: perAppGrayscaleEnabledDictName)
@@ -107,7 +114,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         defaultGrayscaleMenuItem.title = defaultGrayscaleEnabled ? "Grayscale Default: Enabled" : "Grayscale Default: Disabled"
         appSpecificMenuItem.title = currentApplication.localizedName!
 
-        if let appSpecificEnableGrayscale = perAppGrayscaleEnabledDict[currentApplication.bundleIdentifier!] {
+        if let bundleIdentifier = currentApplicationBundleIdentifier,
+           let appSpecificEnableGrayscale = perAppGrayscaleEnabledDict[bundleIdentifier] {
             if appSpecificEnableGrayscale {
                 // grayscale is enabled for this app
                 updateAppSpecificSubMenu(.ENABLED)

--- a/grayscale.xcodeproj/project.pbxproj
+++ b/grayscale.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 53;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -180,9 +180,9 @@
 			buildPhases = (
 				8B25B147247AC6CF00B0BBDD /* Sources */,
 				8B25B148247AC6CF00B0BBDD /* Frameworks */,
+				8B36434524874E4B00F18433 /* Embed Frameworks */,
 				8BFFB00F247ACAE8009AC0A6 /* Resources */,
 				8BFFB024247ACC50009AC0A6 /* Set Build Version and Number */,
-				8B36434524874E4B00F18433 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);


### PR DESCRIPTION
This change fixes a rare bug that causes grayscale to crash when the current application has not declared a bundle identifier (normally found in `Info.plist`).

When building the project for the first time, I was running into linking errors and found them to stem from two causes:
- The "Embed Frameworks" phase being after "Set Build Version and Number"
- MASShortcut's minimum deployment target of 10.10 (Yosemite), which is no longer supported as of Xcode 15.2 (macOS Sonoma 14.2.1 / 23C71), nor includes `libarclite` in macOS's SDK.

While I was able to resolve both issues, I haven't included the relevant fix for the second issue due to MASShortcut being included in grayscale as a git submodule. The upstream repository has been archived, so I'm not sure if I could incorporate the fix. Nevertheless, all one needs to do is select the MASShortcut subproject in Xcode, then navigate Targets > MASShortcut > General > Minimum Deployments and set macOS to at least 10.13 (High Sierra). Fortunately, this does not affect grayscale, as the app's target is 10.15 (Catalina)