### PR TITLE
Add 'Enable Grayscale on Startup' feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,20 @@ Using the grayscale filter can help you reduce your screen time. For more inform
 
 ## Using grayscale
 
-`grayscale` enables or disables grayscale mode based on the active application. It stores a default grayscale value, which determines whether grayscale mode should be on or off for all applications that have not overridden it. To toggle the default value, you can left click the status bar icon or use a keyboard shortcut. Right-clicking the icon brings up a menu, which allows you to view the default value, override it for the active application, and configure the keyboard shortcut.
+`grayscale` enables or disables grayscale mode based on the active application. It stores a default grayscale value, which determines whether grayscale mode should be on or off for all applications that have not overridden it. To toggle the default value, you can left click the status bar icon or use a keyboard shortcut. Right-clicking the icon brings up a menu, which allows you to view the default value, override it for the active application, configure the keyboard shortcut, and enable grayscale on startup.
 
 `grayscale` is designed to make using grayscale mode practical. It's not realistic to keep your screen in grayscale all the time, and automatic transitions reduce the burden of manually turning it on and off. I recommend enabling grayscale by default and disabling it for specific applications that benefit from colors but don't use them to capture your attention, like a text editor with syntax highlighting. Potentially addictive applications that sometimes need color, like web browsers, can then be used with the default setting (i.e. with grayscale enabled), and you can use the keyboard shortcut to toggle grayscale as necessary.
+
+### Enable Grayscale on Startup
+
+`grayscale` includes an option to automatically enable grayscale mode when the application starts, if it was previously disabled. This feature is useful if you want to ensure grayscale is always enabled when you start your computer, even if you disabled it during your previous session.
+
+To enable this feature:
+1. Right-click the grayscale status bar icon
+2. Click "Enable Grayscale on Startup" to toggle the preference
+3. A checkmark will appear when the feature is enabled
+
+When enabled, grayscale will automatically turn on when the app starts, but only if grayscale was previously disabled. If grayscale is already enabled when the app starts, this setting has no effect.
 
 ## Installing grayscale
 

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -12,6 +12,7 @@ import Carbon
 // user defaults keys
 let grayscaleShortcutName = "grayscale_shortcut"
 let perAppGrayscaleEnabledDictName = "grayscale_dict"
+let enableGrayscaleOnStartupName = "enable_grayscale_on_startup"
 
 @NSApplicationMain
 class AppDelegate: NSObject, NSApplicationDelegate {
@@ -22,6 +23,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var currentApplicationBundleIdentifier: String? { currentApplication.bundleIdentifier }
     var defaultGrayscaleEnabled: Bool = false
     var perAppGrayscaleEnabledDict: [String: Bool] = [:]
+    var enableGrayscaleOnStartup: Bool = false
 
     func applicationDidFinishLaunching(_ aNotification: Notification) {
         grayscaleLog("")
@@ -29,6 +31,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         defaultGrayscaleEnabled = grayscaleEnabled()
         currentApplication = NSWorkspace.shared.frontmostApplication!
         perAppGrayscaleEnabledDict = UserDefaults.standard.dictionary(forKey: perAppGrayscaleEnabledDictName) as? [String: Bool] ?? [:]
+        enableGrayscaleOnStartup = UserDefaults.standard.bool(forKey: enableGrayscaleOnStartupName)
+
+        // Enable grayscale on startup if the preference is set and grayscale is currently disabled
+        if enableGrayscaleOnStartup && !grayscaleEnabled() {
+            grayscaleLog("enabling grayscale on startup")
+            enableGrayscale()
+            defaultGrayscaleEnabled = true
+        }
 
         createUI()
         updateUI()
@@ -97,6 +107,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         updateUI()
     }
 
+    @objc func toggleEnableGrayscaleOnStartup(_ sender: Any) {
+        enableGrayscaleOnStartup = !enableGrayscaleOnStartup
+        UserDefaults.standard.set(enableGrayscaleOnStartup, forKey: enableGrayscaleOnStartupName)
+        grayscaleLog("toggled enable grayscale on startup to \(enableGrayscaleOnStartup)")
+        updateUI()
+    }
+
     @objc func statusBarButtonClick(_ sender: Any) {
         let event = NSApp.currentEvent!
         if event.type == NSEvent.EventType.leftMouseUp {
@@ -114,6 +131,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     func updateUI() {
         defaultGrayscaleMenuItem.title = defaultGrayscaleEnabled ? "Grayscale Default: Enabled" : "Grayscale Default: Disabled"
+        enableGrayscaleOnStartupMenuItem.state = enableGrayscaleOnStartup ? .on : .off
         appSpecificMenuItem.title = currentApplication.localizedName!
 
         if let bundleIdentifier = currentApplicationBundleIdentifier,
@@ -137,6 +155,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var statusItem: NSStatusItem!
     var statusMenu: NSMenu!
     var defaultGrayscaleMenuItem: NSMenuItem!
+    var enableGrayscaleOnStartupMenuItem: NSMenuItem!
     var appSpecificMenuItem: NSMenuItem!
     var appSpecificSubMenuItemGrayscaleDefault: NSMenuItem!
     var appSpecificSubMenuItemGrayscaleDisabled: NSMenuItem!
@@ -161,6 +180,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         defaultGrayscaleMenuItem = NSMenuItem(title: "Grayscale Default", action: nil, keyEquivalent: "")
         statusMenu.addItem(defaultGrayscaleMenuItem)
+
+        enableGrayscaleOnStartupMenuItem = NSMenuItem(title: "Enable Grayscale on Startup", action: #selector(toggleEnableGrayscaleOnStartup(_:)), keyEquivalent: "")
+        statusMenu.addItem(enableGrayscaleOnStartupMenuItem)
+        statusMenu.addItem(NSMenuItem.separator())
 
         appSpecificMenuItem = NSMenuItem(title: "App Name", action: nil, keyEquivalent: "")
         appSpecificSubMenuItemGrayscaleDefault = NSMenuItem(title: "Default",  action: #selector(appSpecificMenuClick(_:)), keyEquivalent: "")


### PR DESCRIPTION
Hey, great app!

Sometimes I manually toggle grayscale off and forget to turn it back on. By default I like to have it re-enabled.

This feature gives users an option to always re-enable grayscale at boot, even if they disabled it during their previous session.

- Add new UserDefaults key 'enable_grayscale_on_startup' to store user preference
- Add startup logic to automatically enable grayscale if preference is set and grayscale is currently disabled
- Add new menu item 'Enable Grayscale on Startup' with toggle functionality
- Update UI to show checkmark when startup preference is enabled
- Update README with documentation for the new feature

I've tested it locally and it's working.